### PR TITLE
[Mono.Compiler] Hardcode LLVM dylib dllmap

### DIFF
--- a/data/config.in
+++ b/data/config.in
@@ -41,4 +41,6 @@
 	<dllmap dll="gdiplus.dll" target="@libgdiplus_install_loc@"  os="!windows"/>
 	<dllmap dll="gdi32" target="@libgdiplus_install_loc@" os="!windows"/>
 	<dllmap dll="gdi32.dll" target="@libgdiplus_install_loc@" os="!windows"/>
+	<!-- FIXME: configure magic so LLVM dylib is not hardcoded -->
+	<dllmap dll="libLLVM" target="/usr/local/opt/llvm/lib/libLLVM.dylib" os="!windows"/>
 </configuration>

--- a/mcs/class/Mono.Compiler/README.md
+++ b/mcs/class/Mono.Compiler/README.md
@@ -1,6 +1,7 @@
 * install `brew install llvm`
+* (ensure that the `data/config.in` mapping for `libLLVM` &mdash; which points at `/usr/local/opt/llvm/lib/libLLVM.dylib` &mdash; corresponds to the LLVM dylib that was installed by Homebrew)
 * build mono
 * run `Mono.Compiler` tests:
 ```
-DYLD_FALLBACK_LIBRARY_PATH=/usr/local/opt/llvm/lib make run-test -C mcs/class/Mono.Compiler V=1
+make run-test -C mcs/class/Mono.Compiler V=1
 ```

--- a/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
+++ b/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
@@ -15,7 +15,7 @@ namespace MonoTests.Mono.CompilerInterface
 		[TestFixtureSetUp]
 		public void Init () {
 			runtimeInfo = new RuntimeInformation ();
-			//compiler = new ManagedJIT ();
+			compiler = new ManagedJIT ();
 		}
 
 		


### PR DESCRIPTION
The previous approach of setting `DYLD_FALLBACK_LIBRARY_PATH` was only robust if
System Integrity Protection was turned off.
