### PR TITLE
Initialize MethodBody max stack and locals token.

### DIFF
--- a/mcs/class/Mono.Compiler/Mono.Compiler/ClassInfo.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/ClassInfo.cs
@@ -26,8 +26,17 @@ namespace Mono.Compiler
 		{
 			/* FIXME: methodName is not enough to uniquely determine a method */
 			var m = type.GetMethod (methodName);
-			var bodyBytes = m.GetMethodBody ().GetILAsByteArray ();
-			var body = new SimpleJit.Metadata.MethodBody (bodyBytes);
+			return GetMethodInfoFor (m, methodName);
+		}
+
+		MethodInfo GetMethodInfoFor (System.Reflection.MethodInfo m, string methodName)
+		{
+			var srBody = m.GetMethodBody ();
+			var bodyBytes = srBody.GetILAsByteArray ();
+			var maxStack = srBody.MaxStackSize;
+			var initLocals = srBody.InitLocals;
+			var localsToken = srBody.LocalSignatureMetadataToken;
+			var body = new SimpleJit.Metadata.MethodBody (bodyBytes, maxStack, initLocals, localsToken);
 			return new MethodInfo (this, methodName, body);
 		}
 

--- a/mcs/class/Mono.Compiler/Mono.Compiler/ClassInfo.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/ClassInfo.cs
@@ -7,14 +7,18 @@ namespace Mono.Compiler
 {
 	public class ClassInfo
 	{
-		internal Type type;
+		internal TypeInfo type;
 
 		public string Name { get => type.FullName; }
 
+		ClassInfo (TypeInfo type)
+		{
+			this.type = type;
+		}
+
 		public static ClassInfo FromType (Type t)
 		{
-			var ci = new ClassInfo ();
-			ci.type = t;
+			var ci = new ClassInfo (t.GetTypeInfo ());
 			return ci;
 		}
 

--- a/mcs/class/Mono.Compiler/SimpleJit.Metadata/MethodBody.cs
+++ b/mcs/class/Mono.Compiler/SimpleJit.Metadata/MethodBody.cs
@@ -151,10 +151,12 @@ public class MethodBody {
 		}
 	}
 
-	public MethodBody (byte[] body)
+	public MethodBody (byte[] body, int maxStack, bool initLocals, int localsToken)
 	{
-		// FIXME: locals, maxStack, labels
 		this.body = body;
+		this.maxStack = maxStack;
+		this.initLocals = initLocals;
+		this.localsToken = localsToken;
 	}
 
 	public override string ToString () {

--- a/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
+++ b/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
@@ -89,7 +89,7 @@ namespace MonoTests.Mono.CompilerInterface
 		[Test]
 		public unsafe void TestSimpleRet () {
 			byte[] input = { 0x2a /* OpCodes.Ret*/ };
-			var body = new SimpleJit.Metadata.MethodBody (input);
+			var body = new SimpleJit.Metadata.MethodBody (input, 0, false, 0);
 			MethodInfo mi = new MethodInfo (null, "simpleRet", body);
 			NativeCodeHandle nativeCode;
 


### PR DESCRIPTION
The locals token is not really as useful as `S.R.MethodBody.LocalVariables` but maybe we don't want to create the whole array eagerly?