### PR TITLE
[Mono.Compiler] use generalized execute entry via runtime_invoke wrapper

### DIFF
--- a/mcs/class/Mono.Compiler/Mini/MiniCompiler.cs
+++ b/mcs/class/Mono.Compiler/Mini/MiniCompiler.cs
@@ -14,7 +14,7 @@ namespace Mono.Compiler
 				return CompilationResult.InternalError;
 			}
 
-			nativeCode = new NativeCodeHandle(code, codeLength);
+			nativeCode = new NativeCodeHandle(code, codeLength, methodInfo);
 			return CompilationResult.Ok;
 		}
 

--- a/mcs/class/Mono.Compiler/Mono.Compiler/ClassInfo.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/ClassInfo.cs
@@ -37,7 +37,7 @@ namespace Mono.Compiler
 			var initLocals = srBody.InitLocals;
 			var localsToken = srBody.LocalSignatureMetadataToken;
 			var body = new SimpleJit.Metadata.MethodBody (bodyBytes, maxStack, initLocals, localsToken);
-			return new MethodInfo (this, methodName, body);
+			return new MethodInfo (this, methodName, body, m.MethodHandle);
 		}
 
 	}

--- a/mcs/class/Mono.Compiler/Mono.Compiler/MethodInfo.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/MethodInfo.cs
@@ -1,4 +1,3 @@
-
 using SimpleJit.Metadata;
 using System;
 using System.Reflection.Emit;
@@ -10,14 +9,18 @@ namespace Mono.Compiler
 		public ClassInfo ClassInfo { get; }
 		public string Name { get; }
 		public MethodBody Body { get; }
+		/* TODO: unify with MethodHandle. This is a MonoReflectionMethod in C */
+		public RuntimeMethodHandle RuntimeMethodHandle { get; }
 
-		internal MethodInfo (ClassInfo ci, string name, MethodBody body) {
+		internal MethodInfo (ClassInfo ci, string name, MethodBody body, RuntimeMethodHandle runtimeMethodHandle) {
 			ClassInfo = ci;
 			Name = name;
 			Body = body;
+			RuntimeMethodHandle = runtimeMethodHandle;
 		}
 
 		/* Used only for MiniCompiler. This should be merged with the above constructor. */
+		/* this is a MonoMethod in C */
 		internal IntPtr MethodHandle { get; }
 
 		internal MethodInfo (IntPtr runtimeMethodHandle) {

--- a/mcs/class/Mono.Compiler/Mono.Compiler/NativeCodeHandle.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/NativeCodeHandle.cs
@@ -1,4 +1,3 @@
-﻿
 using System.Runtime.InteropServices;
 
 namespace Mono.Compiler
@@ -8,14 +7,20 @@ namespace Mono.Compiler
 	{
 		byte* blob;
 		long length;
+		MethodInfo mi;
 
 		public byte* Blob {
 			get { return blob; }
 		}
 
-		internal NativeCodeHandle (byte *codeBlob, long codeLength) {
+		public MethodInfo MethodInfo {
+			get { return mi; }
+		}
+
+		public NativeCodeHandle (byte *codeBlob, long codeLength, MethodInfo methodInfo) {
 			blob = codeBlob;
 			length = codeLength;
+			mi = methodInfo;
 		}
 	}
 }

--- a/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
@@ -12,12 +12,10 @@ namespace Mono.Compiler {
 		}
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		extern static int mono_execute_installed_method_2 (InstalledRuntimeCode irc, int arg0, int arg1);
+		extern static object mono_execute_installed_method (InstalledRuntimeCode irc, params object[] args);
 
 		public object ExecuteInstalledMethod (InstalledRuntimeCode irc, params object[] args) {
-			if (args.Length == 2)
-				return mono_execute_installed_method_2 (irc, (int) args [0], (int) args [1]);
-			throw new Exception ("execute installed method: signature not supported yet");
+			return mono_execute_installed_method (irc, args);
 		}
 
 		public ClassInfo GetClassInfoFor (string className)

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -248,6 +248,8 @@ struct _MonoJitInfo {
 	/* Whenever this jit info refers to an interpreter method */
 	gboolean    is_interp:1;
 
+	MonoMethod  *mjit_method; // mjit
+
 	/* FIXME: Embed this after the structure later*/
 	gpointer    gc_info; /* Currently only used by SGen */
 	

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1976,6 +1976,9 @@ mono_runtime_invoke_checked (MonoMethod *method, void *obj, void **params, MonoE
 MonoObjectHandle
 mono_runtime_invoke_handle (MonoMethod *method, MonoObjectHandle obj, void **params, MonoError* error);
 
+gpointer
+mono_invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, gboolean* has_byref_nullables, MonoError *error);
+
 MonoObject*
 mono_runtime_invoke_interpreter (MonoMethod *method, void *obj, void **params, MonoError *error);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5084,7 +5084,7 @@ mono_runtime_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **ex
 
 
 
-/** invoke_array_extract_argument:
+/** mono_invoke_array_extract_argument:
  * @params: array of arguments to the method.
  * @i: the index of the argument to extract.
  * @t: ith type from the method signature.
@@ -5096,8 +5096,8 @@ mono_runtime_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **ex
  *
  * On failure sets @error and returns NULL.
  */
-static gpointer
-invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, gboolean* has_byref_nullables, MonoError *error)
+gpointer
+mono_invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, gboolean* has_byref_nullables, MonoError *error)
 {
 	MonoType *t_orig = t;
 	gpointer result = NULL;
@@ -5344,7 +5344,7 @@ mono_runtime_try_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 		pa = (void **)alloca (sizeof (gpointer) * mono_array_length (params));
 		for (i = 0; i < mono_array_length (params); i++) {
 			MonoType *t = sig->params [i];
-			pa [i] = invoke_array_extract_argument (params, i, t, &has_byref_nullables, error);
+			pa [i] = mono_invoke_array_extract_argument (params, i, t, &has_byref_nullables, error);
 			return_val_if_nok (error, NULL);
 		}
 	}


### PR DESCRIPTION
we need the method signature for that somewhow, so I attach MethodInfo
to NativeCodeHandle.

