### PR TITLE
[mjit] Rework MiniCompiler integration to runtime

### DIFF
--- a/mcs/class/Mono.Compiler/Mini/MiniCompiler.cs
+++ b/mcs/class/Mono.Compiler/Mini/MiniCompiler.cs
@@ -8,7 +8,7 @@ namespace Mono.Compiler
 	{
 		public CompilationResult CompileMethod (IRuntimeInformation runtimeInfo, MethodInfo methodInfo, CompilationFlags flags, out NativeCodeHandle nativeCode)
 		{
-			byte *code = CompileMethod(methodInfo.MethodHandle, out long codeLength);
+			byte *code = CompileMethod(methodInfo.MethodHandle, methodInfo.Flags, out long codeLength);
 			if ((IntPtr) code == IntPtr.Zero) {
 				nativeCode = default(NativeCodeHandle);
 				return CompilationResult.InternalError;
@@ -19,6 +19,6 @@ namespace Mono.Compiler
 		}
 
 		[MethodImpl (MethodImplOptions.InternalCall)]
-		unsafe static extern byte* CompileMethod(IntPtr method, out long codeLength);
+		unsafe static extern byte* CompileMethod(IntPtr method, int flags, out long codeLength);
 	}
 }

--- a/mcs/class/Mono.Compiler/Mono.Compiler/MethodInfo.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/MethodInfo.cs
@@ -22,9 +22,11 @@ namespace Mono.Compiler
 		/* Used only for MiniCompiler. This should be merged with the above constructor. */
 		/* this is a MonoMethod in C */
 		internal IntPtr MethodHandle { get; }
+		internal int Flags { get; }
 
-		internal MethodInfo (IntPtr runtimeMethodHandle) {
+		internal MethodInfo (IntPtr runtimeMethodHandle, int flags) {
 			MethodHandle = runtimeMethodHandle;
+			Flags = flags;
 		}
 	}
 }

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -265,9 +265,6 @@ mono_runtime_init (MonoDomain *domain, MonoThreadStartCB start_cb, MonoThreadAtt
 }
 
 void
-mono_init_compiler_assembly (void);
-
-void
 mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoThreadAttachCB attach_cb, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
@@ -310,8 +307,6 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 	mono_thread_attach (domain);
 
 	mono_type_initialization_init ();
-
-	mono_init_compiler_assembly ();
 
 	if (!mono_runtime_get_no_exec ())
 		create_domain_objects (domain);

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -887,7 +887,6 @@ mono_inflate_generic_signature (MonoMethodSignature *sig, MonoGenericContext *co
 
 typedef struct {
 	MonoImage *corlib;
-	MonoImage *compiler;
 	MonoClass *object_class;
 	MonoClass *byte_class;
 	MonoClass *void_class;

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -792,18 +792,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	return domain;
 }
 
-void
-mono_init_compiler_assembly (void)
-{
-	MonoAssembly *compiler_assembly = NULL;
-
-	compiler_assembly = mono_assembly_load (mono_assembly_name_new ("Mono.Compiler"), NULL, NULL);
-	g_assert (compiler_assembly);
-
-	mono_defaults.compiler = mono_assembly_get_image_internal (compiler_assembly);
-	g_assert (mono_defaults.compiler);
-}
-
 /**
  * mono_init:
  * 

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -80,9 +80,6 @@ HANDLES(ICALL(NATIVEMETHODS_9, "SetProcessWorkingSetSize", ves_icall_Microsoft_W
 HANDLES(ICALL(NATIVEMETHODS_10, "TerminateProcess", ves_icall_Microsoft_Win32_NativeMethods_TerminateProcess))
 HANDLES(ICALL(NATIVEMETHODS_11, "WaitForInputIdle", ves_icall_Microsoft_Win32_NativeMethods_WaitForInputIdle))
 
-ICALL_TYPE(MINICOMPILER, "Mono.Compiler.MiniCompiler", MINICOMPILER_1)
-HANDLES(ICALL(MINICOMPILER_1, "CompileMethod", ves_icall_Mono_Compiler_MiniCompiler_CompileMethod))
-
 #ifndef DISABLE_COM
 ICALL_TYPE(COMPROX, "Mono.Interop.ComInteropProxy", COMPROX_1)
 HANDLES(ICALL(COMPROX_1, "AddProxy", ves_icall_Mono_Interop_ComInteropProxy_AddProxy))

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -667,7 +667,6 @@ typedef struct {
 	void     (*init_delegate) (MonoDelegate *del);
 	MonoObject* (*runtime_invoke) (MonoMethod *method, void *obj, void **params, MonoObject **exc, gboolean force_interpreter, MonoError *error);
 	void*    (*compile_method) (MonoMethod *method, MonoError *error);
-	void*    (*compile_method_with_mini) (MonoMethod *method, MonoError *error);
 	gpointer (*create_jump_trampoline) (MonoDomain *domain, MonoMethod *method, gboolean add_sync_wrapper, MonoError *error);
 	gpointer (*create_jit_trampoline) (MonoDomain *domain, MonoMethod *method, MonoError *error);
 	/* used to free a dynamic method */
@@ -1992,9 +1991,6 @@ mono_runtime_invoke_array_checked (MonoMethod *method, void *obj, MonoArray *par
 
 void* 
 mono_compile_method_checked (MonoMethod *method, MonoError *error);
-
-gpointer
-ves_icall_Mono_Compiler_MiniCompiler_CompileMethod(MonoMethod *method, gint64 *code_length, MonoError *error);
 
 MonoObject*
 mono_runtime_delegate_try_invoke (MonoObject *delegate, void **params,

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -739,30 +739,6 @@ mono_compile_method_checked (MonoMethod *method, MonoError *error)
 }
 
 gpointer
-ves_icall_Mono_Compiler_MiniCompiler_CompileMethod(MonoMethod *method, gint64 *code_length, MonoError *error)
-{
-	MonoDomain *domain;
-	MonoJitInfo *jit_info;
-	gpointer res;
-
-	*code_length = 0;
-
-	g_assert (callbacks.compile_method_with_mini);
-	res = callbacks.compile_method_with_mini(method, error);
-	if (!res)
-		return NULL;
-
-	domain = mono_domain_get ();
-	g_assert (domain);
-
-	jit_info = mono_jit_info_table_find(domain, res);
-	g_assert (jit_info);
-
-	*code_length = (gint64) mono_jit_info_get_code_size(jit_info);
-	return res;
-}
-
-gpointer
 mono_runtime_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean add_sync_wrapper, MonoError *error)
 {
 	gpointer res;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -4016,7 +4016,7 @@ mono_update_jit_stats (MonoCompile *cfg)
  *   Main entry point for the JIT.
  */
 gpointer
-mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, int opt, MonoError *error)
+mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, gint32 opt, MonoError *error)
 {
 	MonoCompile *cfg;
 	gpointer code = NULL;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2003,7 +2003,7 @@ void      mono_disassemble_code             (MonoCompile *cfg, guint8 *code, int
 void      mono_add_patch_info               (MonoCompile *cfg, int ip, MonoJumpInfoType type, gconstpointer target) MONO_LLVM_INTERNAL;
 void      mono_add_patch_info_rel           (MonoCompile *cfg, int ip, MonoJumpInfoType type, gconstpointer target, int relocation) MONO_LLVM_INTERNAL;
 void      mono_remove_patch_info            (MonoCompile *cfg, int ip);
-gpointer  mono_jit_compile_method_inner     (MonoMethod *method, MonoDomain *target_domain, int opt, MonoError *error);
+gpointer  mono_jit_compile_method_inner     (MonoMethod *method, MonoDomain *target_domain, gint32 opt, MonoError *error);
 GList    *mono_varlist_insert_sorted        (MonoCompile *cfg, GList *list, MonoMethodVar *mv, int sort_type);
 GList    *mono_varlist_sort                 (MonoCompile *cfg, GList *list, int sort_type);
 void      mono_analyze_liveness             (MonoCompile *cfg);


### PR DESCRIPTION
We just push it slightly lower in the callstack so it's at a more central place. This gives us a single function through which mini is called from the runtime.