### PR TITLE
BigStep: drop some LLVM in there

### DIFF
--- a/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
@@ -91,7 +91,7 @@ namespace Mono.Compiler.BigStep
 				LLVM.InitializeX86TargetInfo ();
 				LLVM.InitializeX86AsmParser ();
 				LLVM.InitializeX86AsmPrinter ();
-				LLVMMCJITCompilerOptions options = new LLVMMCJITCompilerOptions { NoFramePointerElim = 1 };
+				LLVMMCJITCompilerOptions options = new LLVMMCJITCompilerOptions { NoFramePointerElim = 0 };
 				LLVM.InitializeMCJITCompilerOptions(options);
 				if (LLVM.CreateMCJITCompilerForModule(out var engine, Module, options, out var error) != Success)
 				{

--- a/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
+++ b/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
@@ -132,9 +132,14 @@ namespace MonoTests.Mono.CompilerInterface
 			MethodInfo mi = runtimeInfo.GetMethodInfoFor (ci, "EmptyMethod");
 			NativeCodeHandle nativeCode;
 
-			compiler.CompileMethod (runtimeInfo, mi, CompilationFlags.None, out nativeCode);
+			var result = compiler.CompileMethod (runtimeInfo, mi, CompilationFlags.None, out nativeCode);
 
-			Assert.AreEqual (*nativeCode.Blob, (byte) 0xc3); // 0xc3 is 'RET' in amd64 assembly
+			// InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, nativeCode);
+
+			// runtimeInfo.ExecuteInstalledMethod (irc);
+
+			// FIXME: this returns 0x55 which is some kind of PUSH
+			Assert.AreEqual ((byte) 0xc3, *nativeCode.Blob); // 0xc3 is 'RET' in amd64 assembly
 		}
 	}
 }

--- a/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
+++ b/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
@@ -133,13 +133,11 @@ namespace MonoTests.Mono.CompilerInterface
 			NativeCodeHandle nativeCode;
 
 			var result = compiler.CompileMethod (runtimeInfo, mi, CompilationFlags.None, out nativeCode);
+			InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, nativeCode);
+			runtimeInfo.ExecuteInstalledMethod (irc);
 
-			// InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, nativeCode);
-
-			// runtimeInfo.ExecuteInstalledMethod (irc);
-
-			// FIXME: this returns 0x55 which is some kind of PUSH
-			Assert.AreEqual ((byte) 0xc3, *nativeCode.Blob); // 0xc3 is 'RET' in amd64 assembly
+			/* 0xc3 is `RET` in AMD64 assembly */
+			Assert.AreEqual ((byte) 0xc3, *nativeCode.Blob);
 		}
 	}
 }


### PR DESCRIPTION
It's doing something...

but TestSimpleRet says
```
1) TestSimpleRet (MonoTests.Mono.CompilerInterface.ICompilerTests.TestSimpleRet)
     Expected: 195
  But was:  85
```

Where `85` is `0x55` which is `push rbp`.

Unfortunately if I uncomment
```csharp
			// InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, nativeCode);

			// runtimeInfo.ExecuteInstalledMethod (irc);
```

Instead of running, it crashes in native while calling `mono_install_compilation_result`