### PR TITLE
[Mono.Compiler] remove MethodInfo field from NativecodeHandle

### DIFF
--- a/mcs/class/Mono.Compiler/Mini/MiniCompiler.cs
+++ b/mcs/class/Mono.Compiler/Mini/MiniCompiler.cs
@@ -14,7 +14,7 @@ namespace Mono.Compiler
 				return CompilationResult.InternalError;
 			}
 
-			nativeCode = new NativeCodeHandle(code, codeLength, methodInfo);
+			nativeCode = new NativeCodeHandle(code, codeLength);
 			return CompilationResult.Ok;
 		}
 

--- a/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
@@ -99,7 +99,7 @@ namespace Mono.Compiler.BigStep
 				}
 				IntPtr fnptr = LLVM.GetPointerToGlobal (engine, Function);
 				unsafe {
-					result = new NativeCodeHandle ((byte*)fnptr, -1, methodInfo);
+					result = new NativeCodeHandle ((byte*)fnptr, -1);
 				}
 
 				//FIXME: cleanup in a Dispose method?

--- a/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
@@ -37,7 +37,7 @@ namespace Mono.Compiler.BigStep
 			var r = TranslateBody (env, builder, methodInfo.Body);
 			if (r != Ok)
 				return r;
-			r = builder.Finish (methodInfo, out result);
+			r = builder.Finish (out result);
 			return r;
 		}
 
@@ -79,7 +79,7 @@ namespace Mono.Compiler.BigStep
 			}
 
 
-			internal CompilationResult Finish (MethodInfo methodInfo, out NativeCodeHandle result) {
+			internal CompilationResult Finish (out NativeCodeHandle result) {
 
 				// FIXME: get rid of this printf
 				LLVM.DumpModule (Module);

--- a/mcs/class/Mono.Compiler/Mono.Compiler/IRuntimeInformation.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/IRuntimeInformation.cs
@@ -4,7 +4,7 @@ namespace Mono.Compiler
 {
 	public interface IRuntimeInformation
 	{
-		InstalledRuntimeCode InstallCompilationResult (CompilationResult compilationResult, NativeCodeHandle codeHandle);
+		InstalledRuntimeCode InstallCompilationResult (CompilationResult compilationResult, MethodInfo methodInfo, NativeCodeHandle codeHandle);
 
 		object ExecuteInstalledMethod (InstalledRuntimeCode irc, params object[] args);
 

--- a/mcs/class/Mono.Compiler/Mono.Compiler/NativeCodeHandle.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/NativeCodeHandle.cs
@@ -7,24 +7,18 @@ namespace Mono.Compiler
 	{
 		byte* blob;
 		long length;
-		MethodInfo mi;
 
 		public byte* Blob {
 			get { return blob; }
 		}
 
-		public MethodInfo MethodInfo {
-			get { return mi; }
-		}
-
-		public NativeCodeHandle (byte *codeBlob, long codeLength, MethodInfo methodInfo) {
+		public NativeCodeHandle (byte *codeBlob, long codeLength) {
 			blob = codeBlob;
 			length = codeLength;
-			mi = methodInfo;
 		}
 
 		public static NativeCodeHandle Invalid { get {
-				return new NativeCodeHandle (null, 0, null);
+				return new NativeCodeHandle (null, 0);
 			}
 		}
 	}

--- a/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
@@ -5,10 +5,10 @@ using System.Runtime.CompilerServices;
 namespace Mono.Compiler {
 	public class RuntimeInformation : IRuntimeInformation {
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		extern static InstalledRuntimeCode mono_install_compilation_result (int compilationResult, MethodInfo methodInfo, NativeCodeHandle codeHandle);
+		extern static InstalledRuntimeCode mono_install_compilation_result (int compilationResult, RuntimeMethodHandle handle, NativeCodeHandle codeHandle);
 
 		public InstalledRuntimeCode InstallCompilationResult (CompilationResult compilationResult, MethodInfo methodInfo, NativeCodeHandle codeHandle) {
-			return mono_install_compilation_result ((int) compilationResult, methodInfo, codeHandle);
+			return mono_install_compilation_result ((int) compilationResult, methodInfo.RuntimeMethodHandle, codeHandle);
 		}
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
@@ -5,10 +5,10 @@ using System.Runtime.CompilerServices;
 namespace Mono.Compiler {
 	public class RuntimeInformation : IRuntimeInformation {
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		extern static InstalledRuntimeCode mono_install_compilation_result (int compilationResult, NativeCodeHandle codeHandle);
+		extern static InstalledRuntimeCode mono_install_compilation_result (int compilationResult, MethodInfo methodInfo, NativeCodeHandle codeHandle);
 
-		public InstalledRuntimeCode InstallCompilationResult (CompilationResult compilationResult, NativeCodeHandle codeHandle) {
-			return mono_install_compilation_result ((int) compilationResult, codeHandle);
+		public InstalledRuntimeCode InstallCompilationResult (CompilationResult compilationResult, MethodInfo methodInfo, NativeCodeHandle codeHandle) {
+			return mono_install_compilation_result ((int) compilationResult, methodInfo, codeHandle);
 		}
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
+++ b/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
@@ -37,7 +37,7 @@ namespace MonoTests.Mono.CompilerInterface
 			NativeCodeHandle nativeCode;
 
 			CompilationResult result = compiler.CompileMethod (runtimeInfo, methodInfo, CompilationFlags.None, out nativeCode);
-			InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, nativeCode);
+			InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, methodInfo, nativeCode);
 			
 			int addition = (int) runtimeInfo.ExecuteInstalledMethod (irc, 1, 2);
 			Assert.AreEqual (addition, 3);
@@ -53,9 +53,9 @@ namespace MonoTests.Mono.CompilerInterface
 			                        0xc3};                  /* ret */
 
 			fixed (byte *b = amd64addblob) {
-				NativeCodeHandle nativeCode = new NativeCodeHandle (b, amd64addblob.Length, mi);
+				NativeCodeHandle nativeCode = new NativeCodeHandle (b, amd64addblob.Length);
 
-				InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, nativeCode);
+				InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, mi, nativeCode);
 
 				int sum = (int) runtimeInfo.ExecuteInstalledMethod (irc, 1, 2);
 				Assert.AreEqual (3, sum);
@@ -77,9 +77,9 @@ namespace MonoTests.Mono.CompilerInterface
 			                        0xc3};                  /* ret */
 
 			fixed (byte *b = amd64addblob) {
-				NativeCodeHandle nativeCode = new NativeCodeHandle (b, amd64addblob.Length, mi);
+				NativeCodeHandle nativeCode = new NativeCodeHandle (b, amd64addblob.Length);
 
-				InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, nativeCode);
+				InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, mi, nativeCode);
 
 				int sum = (int) runtimeInfo.ExecuteInstalledMethod (irc, 1, 2, 3);
 				Assert.AreEqual (6, sum);
@@ -133,7 +133,7 @@ namespace MonoTests.Mono.CompilerInterface
 			NativeCodeHandle nativeCode;
 
 			var result = compiler.CompileMethod (runtimeInfo, mi, CompilationFlags.None, out nativeCode);
-			InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, nativeCode);
+			InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, mi, nativeCode);
 			runtimeInfo.ExecuteInstalledMethod (irc);
 
 			/* 0xc3 is `RET` in AMD64 assembly */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4575,7 +4575,6 @@ ves_icall_Mono_Compiler_MiniCompiler_CompileMethod (MonoMethod *method, gint32 o
 struct _NativeCodeHandle {
 	gpointer blob;
 	gint64 length;
-	MonoObject *method_handle; /* Mono.Compiler.MethodInfo */
 };
 typedef struct _NativeCodeHandle NativeCodeHandle;
 
@@ -4585,10 +4584,10 @@ struct _InstalledRuntimeCode {
 typedef struct _InstalledRuntimeCode InstalledRuntimeCode;
 
 static InstalledRuntimeCode*
-ves_icall_mjit_install_compilation_result (int compilation_result, NativeCodeHandle native_code)
+ves_icall_mjit_install_compilation_result (int compilation_result, MonoObject *method_info, NativeCodeHandle native_code)
 {
 	ERROR_DECL (error);
-	gpointer params [0] = {0};
+	gpointer params [0];
 
 	if (compilation_result != 0) {
 		g_printerr ("mjit_install: failed with %d\n", compilation_result);
@@ -4605,7 +4604,7 @@ ves_icall_mjit_install_compilation_result (int compilation_result, NativeCodeHan
 	MonoJitInfo *jinfo = mono_domain_alloc0 (domain, MONO_SIZEOF_JIT_INFO);
 	jinfo->d.installed_runtime_code = key;
 
-	MonoReflectionMethod *method_handle = (MonoReflectionMethod *) mono_runtime_invoke_checked (MethodInfo_get_RuntimeMethodHandle_method, native_code.method_handle, params, error);
+	MonoReflectionMethod *method_handle = (MonoReflectionMethod *) mono_runtime_invoke_checked (MethodInfo_get_RuntimeMethodHandle_method, method_info, params, error);
 	jinfo->mjit_method = method_handle->method;
 	return_val_if_nok (error, NULL);
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4466,7 +4466,6 @@ static MonoMethod *ICompiler_CompileMethod_method;
 
 static MonoClass *MethodInfo_klass;
 static MonoMethod *MethodInfo_ctor_method;
-static MonoMethod *MethodInfo_get_RuntimeMethodHandle_method;
 
 static void
 mjit_initialize (void)
@@ -4494,11 +4493,6 @@ mjit_initialize (void)
 	mono_error_assert_ok (error);
 
 	g_assert (MethodInfo_ctor_method);
-
-	MethodInfo_get_RuntimeMethodHandle_method = mono_class_get_method_from_name_checked (MethodInfo_klass, "get_RuntimeMethodHandle", 0, 0, error);
-	mono_error_assert_ok (error);
-
-	g_assert (MethodInfo_get_RuntimeMethodHandle_method);
 
 	ICompiler_klass = mono_class_from_name_checked (image, "Mono.Compiler", "MiniCompiler", error);
 	mono_error_assert_ok (error);
@@ -4584,11 +4578,8 @@ struct _InstalledRuntimeCode {
 typedef struct _InstalledRuntimeCode InstalledRuntimeCode;
 
 static InstalledRuntimeCode*
-ves_icall_mjit_install_compilation_result (int compilation_result, MonoObject *method_info, NativeCodeHandle native_code)
+ves_icall_mjit_install_compilation_result (int compilation_result, MonoMethod *method, NativeCodeHandle native_code)
 {
-	ERROR_DECL (error);
-	gpointer params [0];
-
 	if (compilation_result != 0) {
 		g_printerr ("mjit_install: failed with %d\n", compilation_result);
 		return NULL;
@@ -4604,13 +4595,9 @@ ves_icall_mjit_install_compilation_result (int compilation_result, MonoObject *m
 	MonoJitInfo *jinfo = mono_domain_alloc0 (domain, MONO_SIZEOF_JIT_INFO);
 	jinfo->d.installed_runtime_code = key;
 
-	MonoReflectionMethod *method_handle = (MonoReflectionMethod *) mono_runtime_invoke_checked (MethodInfo_get_RuntimeMethodHandle_method, method_info, params, error);
-	jinfo->mjit_method = method_handle->method;
-	return_val_if_nok (error, NULL);
+	jinfo->mjit_method = method;
 
 	// TODO: fill more metadata for MonoJitInfo*
-
-	// TODO: prepare proper runtime_invoke.
 
 	if (native_code.length == -1) {
 		/* hack for LLVMSharp that does not easily provide the size of a code blob */


### PR DESCRIPTION
we can just pass it to the install hook directly.

