### PR TITLE
[mjit] Use SimpleJit.Metadata.ClrType to represent CIL types; add LocalVariableInfo

### DIFF
--- a/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
@@ -50,7 +50,7 @@ namespace Mono.Compiler.BigStep
 			}
 
 			// FIXME: get return type from methodInfo signature
-			public RuntimeTypeHandle ReturnType { get => RuntimeInfo.VoidType; }
+			public ClrType ReturnType { get => RuntimeInfo.VoidType; }
 		}
 
 		// encapsulate the LLVM module and builder here.
@@ -151,7 +151,7 @@ namespace Mono.Compiler.BigStep
 
 		CompilationResult TranslateRet (Env env, Builder builder)
 		{
-			if (env.ReturnType.Equals (RuntimeInfo.VoidType)) {
+			if (env.ReturnType == RuntimeInfo.VoidType) {
 				builder.EmitRetVoid ();
 				return Ok;
 			} else

--- a/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
@@ -47,10 +47,10 @@ namespace Mono.Compiler.BigStep
 			public Env (IRuntimeInformation runtimeInfo, MethodInfo methodInfo)
 			{
 				this.RuntimeInfo = runtimeInfo;
+				this.ReturnType = methodInfo.ReturnType;
 			}
 
-			// FIXME: get return type from methodInfo signature
-			public ClrType ReturnType { get => RuntimeInfo.VoidType; }
+			public ClrType ReturnType { get; }
 		}
 
 		// encapsulate the LLVM module and builder here.

--- a/mcs/class/Mono.Compiler/Mono.Compiler.dll.sources
+++ b/mcs/class/Mono.Compiler/Mono.Compiler.dll.sources
@@ -33,7 +33,9 @@ SimpleJit.CIL/Image.cs
 SimpleJit.CIL/Opcode.cs
 SimpleJit.CIL/OpcodesTableGenerated.cs
 
+SimpleJit.Metadata/ClrType.cs
 SimpleJit.Metadata/MethodBody.cs
+SimpleJit.Metadata/LocalVariableInfo.cs
 
 SimpleJit.Extensions/StreamExtensions.cs
 

--- a/mcs/class/Mono.Compiler/Mono.Compiler.dll.sources
+++ b/mcs/class/Mono.Compiler/Mono.Compiler.dll.sources
@@ -36,6 +36,8 @@ SimpleJit.CIL/OpcodesTableGenerated.cs
 SimpleJit.Metadata/ClrType.cs
 SimpleJit.Metadata/MethodBody.cs
 SimpleJit.Metadata/LocalVariableInfo.cs
+SimpleJit.Metadata/ParameterInfo.cs
+
 
 SimpleJit.Extensions/StreamExtensions.cs
 

--- a/mcs/class/Mono.Compiler/Mono.Compiler/ClassInfo.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/ClassInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 using SimpleJit.Metadata;
@@ -36,8 +37,20 @@ namespace Mono.Compiler
 			var maxStack = srBody.MaxStackSize;
 			var initLocals = srBody.InitLocals;
 			var localsToken = srBody.LocalSignatureMetadataToken;
-			var body = new SimpleJit.Metadata.MethodBody (bodyBytes, maxStack, initLocals, localsToken);
+			var locals = LocalVariableInfo (srBody.LocalVariables);
+			var body = new SimpleJit.Metadata.MethodBody (bodyBytes, maxStack, initLocals, localsToken, locals);
 			return new MethodInfo (this, methodName, body, m.MethodHandle);
+		}
+
+		IList<SimpleJit.Metadata.LocalVariableInfo> LocalVariableInfo (IList<System.Reflection.LocalVariableInfo> locals)
+		{
+			SimpleJit.Metadata.LocalVariableInfo[] res = new SimpleJit.Metadata.LocalVariableInfo[locals.Count];
+			int i = 0;
+			foreach (var l in locals) {
+				var t = RuntimeInformation.ClrTypeFromType (l.LocalType);
+				res[i++] = new SimpleJit.Metadata.LocalVariableInfo (t, l.LocalIndex);
+			}
+			return res;
 		}
 
 	}

--- a/mcs/class/Mono.Compiler/Mono.Compiler/ClassInfo.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/ClassInfo.cs
@@ -32,6 +32,7 @@ namespace Mono.Compiler
 
 		MethodInfo GetMethodInfoFor (System.Reflection.MethodInfo m, string methodName)
 		{
+			var parameters = Array.Empty<SimpleJit.Metadata.ParameterInfo> (); /* FIXME fill this in from S.R.MethodInfo */
 			var srBody = m.GetMethodBody ();
 			var bodyBytes = srBody.GetILAsByteArray ();
 			var maxStack = srBody.MaxStackSize;
@@ -39,7 +40,7 @@ namespace Mono.Compiler
 			var localsToken = srBody.LocalSignatureMetadataToken;
 			var locals = LocalVariableInfo (srBody.LocalVariables);
 			var body = new SimpleJit.Metadata.MethodBody (bodyBytes, maxStack, initLocals, localsToken, locals);
-			return new MethodInfo (this, methodName, body, m.MethodHandle);
+			return new MethodInfo (this, methodName, body, m.MethodHandle, RuntimeInformation.ClrTypeFromType (m.ReturnType), parameters);
 		}
 
 		IList<SimpleJit.Metadata.LocalVariableInfo> LocalVariableInfo (IList<System.Reflection.LocalVariableInfo> locals)

--- a/mcs/class/Mono.Compiler/Mono.Compiler/IRuntimeInformation.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/IRuntimeInformation.cs
@@ -1,5 +1,7 @@
 using System;
 
+using SimpleJit.Metadata;
+
 namespace Mono.Compiler
 {
 	public interface IRuntimeInformation
@@ -12,6 +14,6 @@ namespace Mono.Compiler
 
 		MethodInfo GetMethodInfoFor (ClassInfo classInfo, string methodName);
 
-		RuntimeTypeHandle VoidType { get; }
+		ClrType VoidType { get; }
 	}
 }

--- a/mcs/class/Mono.Compiler/Mono.Compiler/MethodInfo.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/MethodInfo.cs
@@ -1,6 +1,7 @@
-using SimpleJit.Metadata;
 using System;
+using System.Collections.Generic;
 using System.Reflection.Emit;
+using SimpleJit.Metadata;
 
 namespace Mono.Compiler
 {
@@ -13,12 +14,14 @@ namespace Mono.Compiler
 		/* this is a MonoMethod in C */
 		internal RuntimeMethodHandle RuntimeMethodHandle { get; }
 
-		public MethodInfo (ClassInfo ci, string name, MethodBody body, RuntimeMethodHandle runtimeMethodHandle)
+		internal MethodInfo (ClassInfo ci, string name, MethodBody body, RuntimeMethodHandle runtimeMethodHandle, ClrType returnType, IReadOnlyCollection<ParameterInfo> parameters)
 			: this (runtimeMethodHandle)
 		{
 			ClassInfo = ci;
 			Name = name;
 			Body = body;
+			ReturnType = returnType;
+			Parameters = parameters;
 		}
 
 		/* Used by MiniCompiler */
@@ -26,5 +29,9 @@ namespace Mono.Compiler
 		{
 			RuntimeMethodHandle = runtimeMethodHandle;
 		}
+
+		internal ClrType ReturnType { get ; }
+
+		internal IReadOnlyCollection<ParameterInfo> Parameters { get ; }
 	}
 }

--- a/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
@@ -2,6 +2,8 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
+using SimpleJit.Metadata;
+
 namespace Mono.Compiler {
 	public class RuntimeInformation : IRuntimeInformation {
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -29,7 +31,13 @@ namespace Mono.Compiler {
 			return classInfo.GetMethodInfoFor (methodName);
 		}
 
-		public RuntimeTypeHandle VoidType { get => typeof (void).TypeHandle; }
+		public ClrType VoidType { get => ClrTypeFromType (typeof (void)); }
 
+
+		internal static ClrType ClrTypeFromType (Type t)
+		{
+			return new ClrType (t.TypeHandle);
+		}
+	       
 	}
 }

--- a/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
@@ -31,7 +31,36 @@ namespace Mono.Compiler {
 			return classInfo.GetMethodInfoFor (methodName);
 		}
 
+		/* Primitive types */
 		public ClrType VoidType { get => ClrTypeFromType (typeof (void)); }
+
+		public ClrType BoolType { get => ClrTypeFromType (typeof (bool)); }
+
+		public ClrType CharType { get => ClrTypeFromType (typeof (char)); }
+
+		public ClrType ObjectType { get => ClrTypeFromType (typeof (object)); }
+
+		public ClrType StringType { get => ClrTypeFromType (typeof (string)); }
+
+		public ClrType Int8Type { get => ClrTypeFromType (typeof (System.SByte)); }
+		public ClrType UInt8Type { get => ClrTypeFromType (typeof (System.Byte)); }
+
+		public ClrType Int16Type { get => ClrTypeFromType (typeof (System.Int16)); }
+		public ClrType UInt16Type { get => ClrTypeFromType (typeof (System.UInt16)); }
+
+		public ClrType Int32Type { get => ClrTypeFromType (typeof (System.Int32)); }
+		public ClrType UInt32Type { get => ClrTypeFromType (typeof (System.UInt32)); }
+
+		public ClrType Int64Type { get => ClrTypeFromType (typeof (System.Int16)); }
+		public ClrType UInt64Type { get => ClrTypeFromType (typeof (System.UInt16)); }
+
+		public ClrType NativeIntType { get => ClrTypeFromType (typeof (System.IntPtr)); }
+		public ClrType NativeUnsignedIntType { get => ClrTypeFromType (typeof (System.UIntPtr)); }
+
+		public ClrType Float32Type { get => ClrTypeFromType (typeof (System.Single)); }
+		public ClrType Float64Type { get => ClrTypeFromType (typeof (System.Double)); }
+
+		public ClrType TypedRefType { get => ClrTypeFromType (typeof (System.TypedReference)); }
 
 
 		internal static ClrType ClrTypeFromType (Type t)

--- a/mcs/class/Mono.Compiler/SimpleJit.Metadata/ClrType.cs
+++ b/mcs/class/Mono.Compiler/SimpleJit.Metadata/ClrType.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace SimpleJit.Metadata
+{
+	public struct ClrType {
+		private System.RuntimeTypeHandle rttype;
+
+		internal ClrType (System.RuntimeTypeHandle rttype) {
+			this.rttype = rttype;
+		}
+
+		/// Escape hatch, use sparingly
+		public Type AsSystemType { get => Type.GetTypeFromHandle (rttype); }
+
+		public override bool Equals (object obj)
+		{
+			if (obj == null || GetType () != obj.GetType ())
+				return false;
+			return rttype.Equals (((ClrType)obj).rttype);
+		}
+
+		public bool Equals (ClrType other)
+		{
+			return rttype.Equals (other.rttype);
+		}
+
+		public override int GetHashCode ()
+		{
+			return rttype.GetHashCode ();
+		}
+
+		public static bool operator == (ClrType left, ClrType right)
+		{
+			return left.Equals (right);
+		}
+
+		public static bool operator != (ClrType left, ClrType right)
+		{
+			return !left.Equals (right);
+		}
+
+	}
+}

--- a/mcs/class/Mono.Compiler/SimpleJit.Metadata/LocalVariableInfo.cs
+++ b/mcs/class/Mono.Compiler/SimpleJit.Metadata/LocalVariableInfo.cs
@@ -1,0 +1,17 @@
+
+namespace SimpleJit.Metadata
+{
+	public class LocalVariableInfo
+	{
+		public ClrType LocalType;
+		public int LocalIndex;
+
+		public LocalVariableInfo (ClrType t, int idx)
+		{
+			LocalType = t;
+			LocalIndex = idx;
+		}
+		
+	}
+
+}

--- a/mcs/class/Mono.Compiler/SimpleJit.Metadata/MethodBody.cs
+++ b/mcs/class/Mono.Compiler/SimpleJit.Metadata/MethodBody.cs
@@ -27,6 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 using System;
+using System.Collections.Generic;
 using SimpleJit.CIL;
 using Mono;
 
@@ -99,21 +100,25 @@ public class MethodBody {
 	int maxStack;
 	bool initLocals;
 	int localsToken;
+	IList<LocalVariableInfo> localInfo;
 
 	public byte[] Body {
 		get { return body; }
 	}
+#if FIXME_USE_SIMPLEJIT_METADATA
 	// II.25.4.4
 	const int FlagsFormatMask   = 0x03;
 	const int FlagsFatFormat 	= 0x03;
 	const int FlagsTinyFormat   = 0x02;
 	const int FlagsMoreSections = 0x08;
 	const int FlagsInitLocals   = 0x10;
+#endif
 
 	public IlIterator GetIterator () {
 		return new IlIterator (body);
 	}
 
+#if FIXME_USE_SIMPLEJIT_METADATA
 	public MethodBody (Image image, int index) {
 		byte[] data = image.data;
 		if ((data [index] & FlagsFormatMask) == FlagsTinyFormat) {//tiny format
@@ -150,18 +155,23 @@ public class MethodBody {
 			throw new Exception ("Invalid body method body format " + (data [index] & 0x3));
 		}
 	}
+#endif // FIXME_USE_SIMPLEJIT_METADATA
 
-	public MethodBody (byte[] body, int maxStack, bool initLocals, int localsToken)
+	public MethodBody (byte[] body, int maxStack, bool initLocals, int localsToken, IList<LocalVariableInfo> localInfo)
 	{
 		this.body = body;
 		this.maxStack = maxStack;
 		this.initLocals = initLocals;
 		this.localsToken = localsToken;
+		this.localInfo = localInfo;
 	}
 
 	public override string ToString () {
 		return $"method-body maxStack {maxStack} bodySize {body.Length} localsTok 0x{localsToken:X}";
 	}
+
+
+	public IList<LocalVariableInfo> LocalVariables { get => localInfo; }
 }
 
 }

--- a/mcs/class/Mono.Compiler/SimpleJit.Metadata/ParameterInfo.cs
+++ b/mcs/class/Mono.Compiler/SimpleJit.Metadata/ParameterInfo.cs
@@ -1,0 +1,17 @@
+
+namespace SimpleJit.Metadata
+{
+	public class ParameterInfo
+	{
+		public ClrType ParameterType;
+		public int Position;
+
+
+		public ParameterInfo (ClrType parameterType, int idx)
+		{
+			ParameterType = parameterType;
+			Position = idx;
+		}
+	}
+
+}

--- a/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
+++ b/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
@@ -128,7 +128,7 @@ namespace MonoTests.Mono.CompilerInterface
 			ClassInfo ci = runtimeInfo.GetClassInfoFor (typeof (ICompilerTests).AssemblyQualifiedName);
 
 			byte[] input = { 0x2a /* OpCodes.Ret*/ };
-			var body = new SimpleJit.Metadata.MethodBody (input, 0, false, 0);
+			var body = new SimpleJit.Metadata.MethodBody (input, 0, false, 0, Array.Empty<SimpleJit.Metadata.LocalVariableInfo>());
 			MethodInfo mi = runtimeInfo.GetMethodInfoFor (ci, "EmptyMethod");
 			NativeCodeHandle nativeCode;
 


### PR DESCRIPTION

ClrType is just a wrapper around System.RuntimeTypeHandle for now, but better than using
it directly.

LocalVariableInfo is built up from S.R.LocalVariableInfo
