### PR TITLE
Static field load for int32 fields for new backend

### DIFF
--- a/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/BigStep.cs
@@ -38,11 +38,11 @@ namespace Mono.Compiler.BigStep
 			result = NativeCodeHandle.Invalid;
 			try
 			{
-				BitCodeEmitter processor = new BitCodeEmitter(methodInfo){
+				BitCodeEmitter processor = new BitCodeEmitter (RuntimeInfo, methodInfo) {
 					// PrintDebugInfo = true,
 					VerifyGeneratedCode = true
 				};
-				CILSymbolicExecutor exec = new CILSymbolicExecutor(processor, RuntimeInfo, methodInfo);
+				CILSymbolicExecutor exec = new CILSymbolicExecutor (processor, RuntimeInfo, methodInfo);
 				exec.Execute();
 				result = processor.Yield();
 				return CompilationResult.Ok;

--- a/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/CILSymbolicExecutor.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler.BigStep/CILSymbolicExecutor.cs
@@ -19,6 +19,7 @@ namespace Mono.Compiler.BigStep {
 	public class CILSymbolicExecutor : INameGenerator {
 		private IOperationProcessor processor;
 		private IRuntimeInformation runtime;
+		private MethodInfo methodInfo;
 		private MethodBody body;
 
 		private Stack<TempOperand> stack;
@@ -40,6 +41,7 @@ namespace Mono.Compiler.BigStep {
 		{
 			this.processor = processor;
 			this.runtime = runtime;
+			this.methodInfo = methodInfo;
 			this.body = methodInfo.Body;
 
 			this.stack = new Stack<TempOperand>();
@@ -309,6 +311,12 @@ namespace Mono.Compiler.BigStep {
 						operands.Add (locals[opParam]);
 						break;
 						// TODO:  ExtendedOpcode.Stloc
+					case Opcode.Ldsfld:
+						int token = iter.DecodeParamI ();
+						FieldInfo fieldInfo = runtime.GetFieldInfoForToken (methodInfo, token);
+						operands.Add (new Int32ConstOperand (token));
+						output = new TempOperand (this, runtime.Int32Type); /* FIXME: look up the field info! */
+						break;
 				}
 
 				// 2) Determine the result type for values to push into stack

--- a/mcs/class/Mono.Compiler/Mono.Compiler.dll.sources
+++ b/mcs/class/Mono.Compiler/Mono.Compiler.dll.sources
@@ -7,6 +7,7 @@ Mono.Compiler/CompilationResult.cs
 Mono.Compiler/ICompiler.cs
 Mono.Compiler/IRuntimeInformation.cs
 Mono.Compiler/InstalledRuntimeCode.cs
+Mono.Compiler/FieldInfo.cs
 Mono.Compiler/ManagedJIT.cs
 Mono.Compiler/MethodInfo.cs
 Mono.Compiler/NativeCodeHandle.cs

--- a/mcs/class/Mono.Compiler/Mono.Compiler/FieldInfo.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/FieldInfo.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Mono.Compiler
+{
+	public class FieldInfo
+	{
+		internal System.Reflection.FieldInfo srFieldInfo;
+		public ClassInfo Parent { get; }
+
+		internal FieldInfo (System.Reflection.FieldInfo srfi) {
+			this.srFieldInfo = srfi;
+			this.Parent = ClassInfo.FromType (srfi.DeclaringType);
+		}
+
+		public bool IsStatic {
+			get {
+				return srFieldInfo.IsStatic;
+			}
+		}
+
+	}
+}

--- a/mcs/class/Mono.Compiler/Mono.Compiler/IRuntimeInformation.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/IRuntimeInformation.cs
@@ -14,6 +14,10 @@ namespace Mono.Compiler
 
 		MethodInfo GetMethodInfoFor (ClassInfo classInfo, string methodName);
 
+		FieldInfo GetFieldInfoForToken (MethodInfo mi, int token);
+
+		Int64 ComputeFieldAddress (FieldInfo fi);
+
 		ClrType VoidType { get; }
 
 		ClrType Int32Type { get; }

--- a/mcs/class/Mono.Compiler/Mono.Compiler/IRuntimeInformation.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/IRuntimeInformation.cs
@@ -16,7 +16,7 @@ namespace Mono.Compiler
 
 		FieldInfo GetFieldInfoForToken (MethodInfo mi, int token);
 
-		Int64 ComputeFieldAddress (FieldInfo fi);
+		IntPtr ComputeFieldAddress (FieldInfo fi);
 
 		ClrType VoidType { get; }
 

--- a/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
@@ -40,9 +40,9 @@ namespace Mono.Compiler {
 		}
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		static extern Int64 ComputeStaticFieldAddress (RuntimeFieldHandle handle);
+		static extern IntPtr ComputeStaticFieldAddress (RuntimeFieldHandle handle);
 
-		public Int64 ComputeFieldAddress (FieldInfo fi) {
+		public IntPtr ComputeFieldAddress (FieldInfo fi) {
 			if (!fi.IsStatic)
 				throw new InvalidOperationException ("field isn't static");
 			return ComputeStaticFieldAddress (fi.srFieldInfo.FieldHandle);

--- a/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
+++ b/mcs/class/Mono.Compiler/Mono.Compiler/RuntimeInformation.cs
@@ -31,6 +31,23 @@ namespace Mono.Compiler {
 			return classInfo.GetMethodInfoFor (methodName);
 		}
 
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		static extern System.Reflection.FieldInfo GetSRFieldInfoForToken (RuntimeMethodHandle handle, int token);
+
+		public FieldInfo GetFieldInfoForToken (MethodInfo mi, int token) {
+			System.Reflection.FieldInfo srfi = GetSRFieldInfoForToken (mi.RuntimeMethodHandle, token);
+			return new FieldInfo (srfi);
+		}
+
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		static extern Int64 ComputeStaticFieldAddress (RuntimeFieldHandle handle);
+
+		public Int64 ComputeFieldAddress (FieldInfo fi) {
+			if (!fi.IsStatic)
+				throw new InvalidOperationException ("field isn't static");
+			return ComputeStaticFieldAddress (fi.srFieldInfo.FieldHandle);
+		}
+
 		/* Primitive types */
 		public ClrType VoidType { get => ClrTypeFromType (typeof (void)); }
 		public ClrType Int32Type { get => ClrTypeFromType (typeof (System.Int32)); }

--- a/mcs/class/Mono.Compiler/SimpleJit.Metadata/ClrType.cs
+++ b/mcs/class/Mono.Compiler/SimpleJit.Metadata/ClrType.cs
@@ -39,5 +39,9 @@ namespace SimpleJit.Metadata
 			return !left.Equals (right);
 		}
 
+		public static ClrType MakePointerType (ClrType ty)
+		{
+			return new ClrType (ty.AsSystemType.MakePointerType ().TypeHandle);
+		}
 	}
 }

--- a/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
+++ b/mcs/class/Mono.Compiler/Test/ICompilerInterfaceTest.cs
@@ -38,6 +38,11 @@ namespace MonoTests.Mono.CompilerInterface
 			return a + b + c;
 		}
 
+		public static int staticField = 0x1337;
+		public static int StaticFieldReadMethod () {
+			return staticField;
+		}
+
 		[Test]
 		public void TestAddMethod () {
 			ClassInfo ci = runtimeInfo.GetClassInfoFor (typeof (ICompilerTests).AssemblyQualifiedName);
@@ -183,6 +188,21 @@ namespace MonoTests.Mono.CompilerInterface
 			Assert.IsNotNull (o);
 			Assert.AreEqual (typeof(int), o.GetType ());
 			Assert.AreEqual (42, (int)o);
+		}
+
+		[Test]
+		public unsafe void TestStaticFieldRead () {
+			ClassInfo ci = runtimeInfo.GetClassInfoFor (typeof (ICompilerTests).AssemblyQualifiedName);
+			MethodInfo mi = runtimeInfo.GetMethodInfoFor (ci, "StaticFieldReadMethod");
+
+			NativeCodeHandle nativeCode;
+
+			var result = compiler.CompileMethod (runtimeInfo, mi, CompilationFlags.None, out nativeCode);
+			InstalledRuntimeCode irc = runtimeInfo.InstallCompilationResult (result, mi, nativeCode);
+			var o = runtimeInfo.ExecuteInstalledMethod (irc);
+			Assert.IsNotNull (o);
+			Assert.AreEqual (typeof(int), o.GetType ());
+			Assert.AreEqual (0x1337, (int)o);
 		}
 	}
 }

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -80,6 +80,10 @@ HANDLES(ICALL(NATIVEMETHODS_9, "SetProcessWorkingSetSize", ves_icall_Microsoft_W
 HANDLES(ICALL(NATIVEMETHODS_10, "TerminateProcess", ves_icall_Microsoft_Win32_NativeMethods_TerminateProcess))
 HANDLES(ICALL(NATIVEMETHODS_11, "WaitForInputIdle", ves_icall_Microsoft_Win32_NativeMethods_WaitForInputIdle))
 
+ICALL_TYPE(COMPILERRTINFO, "Mono.Compiler.RuntimeInformation", COMPILERRTINFO_1)
+HANDLES(ICALL(COMPILERRTINFO_1, "ComputeStaticFieldAddress", ves_icall_Mono_Compiler_RuntimeInformation_ComputeStaticFieldAddress))
+HANDLES(ICALL(COMPILERRTINFO_2, "GetSRFieldInfoForToken", ves_icall_Mono_Compiler_RuntimeInformation_GetSRFieldInfoForToken))
+
 #ifndef DISABLE_COM
 ICALL_TYPE(COMPROX, "Mono.Interop.ComInteropProxy", COMPROX_1)
 HANDLES(ICALL(COMPROX_1, "AddProxy", ves_icall_Mono_Interop_ComInteropProxy_AddProxy))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5681,6 +5681,34 @@ ves_icall_Mono_RuntimeMarshal_FreeAssemblyName (MonoAssemblyName *aname, gboolea
 		g_free (aname);
 }
 
+ICALL_EXPORT MonoReflectionFieldHandle
+ves_icall_Mono_Compiler_RuntimeInformation_GetSRFieldInfoForToken (MonoMethod *method, int token, MonoError *error)
+{
+	MonoGenericContext generic_context;
+	MonoClass *klass = NULL;
+	MonoImage *image = m_class_get_image (method->klass);
+
+	MonoClassField *field = mono_field_from_token_checked (image, token, &klass, &generic_context, error);
+	g_assert (field);
+
+	return mono_field_get_object_handle (mono_domain_get (), field->parent, field, error);
+}
+
+ICALL_EXPORT guint64
+ves_icall_Mono_Compiler_RuntimeInformation_ComputeStaticFieldAddress (MonoClassField *field)
+{
+	// TODO: check mono_class_static_field_address in jit-icalls.c
+	ERROR_DECL (error);
+	MonoDomain *domain = mono_domain_get ();
+
+	mono_class_init (field->parent);
+	MonoVTable *vtable = mono_class_vtable_checked (domain, field->parent, error);
+
+	guint64 addr = (guint64) ((char *) mono_vtable_get_static_field_data (vtable) + field->offset);
+	// g_print ("the address: %p, value: %p\n", addr, *(guint64 *) addr);
+	return addr;
+}
+
 ICALL_EXPORT void
 ves_icall_Mono_Runtime_DisableMicrosoftTelemetry (MonoError *error)
 {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5694,7 +5694,7 @@ ves_icall_Mono_Compiler_RuntimeInformation_GetSRFieldInfoForToken (MonoMethod *m
 	return mono_field_get_object_handle (mono_domain_get (), field->parent, field, error);
 }
 
-ICALL_EXPORT guint64
+ICALL_EXPORT gpointer
 ves_icall_Mono_Compiler_RuntimeInformation_ComputeStaticFieldAddress (MonoClassField *field)
 {
 	// TODO: check mono_class_static_field_address in jit-icalls.c
@@ -5704,7 +5704,7 @@ ves_icall_Mono_Compiler_RuntimeInformation_ComputeStaticFieldAddress (MonoClassF
 	mono_class_init (field->parent);
 	MonoVTable *vtable = mono_class_vtable_checked (domain, field->parent, error);
 
-	guint64 addr = (guint64) ((char *) mono_vtable_get_static_field_data (vtable) + field->offset);
+	gpointer addr = ((char *) mono_vtable_get_static_field_data (vtable) + field->offset);
 	// g_print ("the address: %p, value: %p\n", addr, *(guint64 *) addr);
 	return addr;
 }


### PR DESCRIPTION
Only does Int32 right now.

Also bot the `CILSymbolicExecutor` and the llvm backend lookup the field info from the token.

It would be nice if there was an Operand for FieldInfo.  But when I tried that I got into trouble with `MakeStorageTypeValue`